### PR TITLE
Yt-dlp dependency update

### DIFF
--- a/app/dep_dl.py
+++ b/app/dep_dl.py
@@ -81,9 +81,8 @@ class DownloaderUi(QWidget, Ui_w_Downloader):
             QTimer.singleShot(0, self.finished.emit)
 
     def get_file_checksum(self, path):
-        with open(path, "rb") as f:
-            checksum = file_digest(f, "sha256").hexdigest()
-            return checksum
+        f = open(path, "rb")
+        return file_digest(f, "sha256").hexdigest()
 
     def fetch_latest_checksum(self, url, executable):
         try:
@@ -108,11 +107,9 @@ class DownloaderUi(QWidget, Ui_w_Downloader):
         os_ = platform.system()
 
         if shutil.which('yt-dlp'):
-            # check if dependency is in bin folder
             yt_dlp_path = os.path.join(BIN, "yt-dlp.exe" if os_ == "Windows" else "yt-dlp")
             
             if os.path.exists(yt_dlp_path):
-                # dependency is in bin folder - compare checksums
                 yt_dlp_checksum_url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/SHA2-256SUMS"
                 file_checksum = self.get_file_checksum(yt_dlp_path)
                 latest_checksum = self.fetch_latest_checksum(yt_dlp_checksum_url, binaries[os_]['yt-dlp'])

--- a/app/dep_dl.py
+++ b/app/dep_dl.py
@@ -12,7 +12,7 @@ from PySide6.QtCore import QThread, Signal, QTimer
 from PySide6.QtWidgets import QWidget
 from tqdm import tqdm
 
-from hashlib import file_digest
+from hashlib import sha256
 
 from ui.download_ui import Ui_w_Downloader
 
@@ -81,8 +81,13 @@ class DownloaderUi(QWidget, Ui_w_Downloader):
             QTimer.singleShot(0, self.finished.emit)
 
     def get_file_checksum(self, path):
-        f = open(path, "rb")
-        return file_digest(f, "sha256").hexdigest()
+        h  = sha256()
+        b  = bytearray(128*1024)
+        mv = memoryview(b)
+        with open(path, 'rb', buffering=0) as f:
+            while n := f.readinto(mv):
+                h.update(mv[:n])
+        return h.hexdigest()
 
     def fetch_latest_checksum(self, url, executable):
         try:

--- a/app/dep_dl.py
+++ b/app/dep_dl.py
@@ -67,10 +67,11 @@ class Downloader(QThread):
 class DownloaderUi(QWidget, Ui_w_Downloader):
     finished = Signal()
 
-    def __init__(self):
+    def __init__(self, auto_update):
         super().__init__()
         self.setupUi(self)
         self.missing = []
+        self.auto_update = auto_update
 
         self.get_missing_dep()
 
@@ -114,7 +115,7 @@ class DownloaderUi(QWidget, Ui_w_Downloader):
         if shutil.which('yt-dlp'):
             yt_dlp_path = os.path.join(BIN, "yt-dlp.exe" if os_ == "Windows" else "yt-dlp")
             
-            if os.path.exists(yt_dlp_path):
+            if os.path.exists(yt_dlp_path) and self.auto_update:
                 yt_dlp_checksum_url = "https://github.com/yt-dlp/yt-dlp/releases/latest/download/SHA2-256SUMS"
                 file_checksum = self.get_file_checksum(yt_dlp_path)
                 latest_checksum = self.fetch_latest_checksum(yt_dlp_checksum_url, binaries[os_]['yt-dlp'])

--- a/app/ui/update.ui
+++ b/app/ui/update.ui
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>w_autoupdate</class>
+ <widget class="QWidget" name="w_autoupdate">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>344</width>
+    <height>163</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Enable Automatic Updates?</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="assets/icons.qrc">
+    <normaloff>:/icon/yt-dlp-gui.ico</normaloff>:/icon/yt-dlp-gui.ico</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Would you like to automatically install any updates to yt-dlp on startup in the future? You can change this preference in the 'conf.json' configuration file.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="cb_autoupdate">
+     <property name="text">
+      <string>Check for dependency updates on startup.</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="b_confirm">
+     <property name="text">
+      <string>OK</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="assets/icons.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/app/ui/update_ui.py
+++ b/app/ui/update_ui.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'update.ui'
+##
+## Created by: Qt User Interface Compiler version 6.6.0
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QApplication, QCheckBox, QLabel, QPushButton,
+    QSizePolicy, QVBoxLayout, QWidget)
+import ui.icons_rc
+
+class Ui_w_autoupdate(object):
+    def setupUi(self, w_autoupdate):
+        if not w_autoupdate.objectName():
+            w_autoupdate.setObjectName(u"w_autoupdate")
+        w_autoupdate.setWindowModality(Qt.NonModal)
+        w_autoupdate.resize(344, 163)
+        icon = QIcon()
+        icon.addFile(u":/icon/yt-dlp-gui.ico", QSize(), QIcon.Normal, QIcon.Off)
+        w_autoupdate.setWindowIcon(icon)
+        self.verticalLayout = QVBoxLayout(w_autoupdate)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.label = QLabel(w_autoupdate)
+        self.label.setObjectName(u"label")
+        self.label.setWordWrap(True)
+
+        self.verticalLayout.addWidget(self.label)
+
+        self.cb_autoupdate = QCheckBox(w_autoupdate)
+        self.cb_autoupdate.setObjectName(u"cb_autoupdate")
+        self.cb_autoupdate.setChecked(True)
+
+        self.verticalLayout.addWidget(self.cb_autoupdate)
+
+        self.b_confirm = QPushButton(w_autoupdate)
+        self.b_confirm.setObjectName(u"b_confirm")
+
+        self.verticalLayout.addWidget(self.b_confirm)
+
+
+        self.retranslateUi(w_autoupdate)
+
+        QMetaObject.connectSlotsByName(w_autoupdate)
+    # setupUi
+
+    def retranslateUi(self, w_autoupdate):
+        w_autoupdate.setWindowTitle(QCoreApplication.translate("w_autoupdate", u"Enable Automatic Updates?", None))
+        self.label.setText(QCoreApplication.translate("w_autoupdate", u"Would you like to automatically install any updates to yt-dlp on startup in the future? You can change this preference in the \'conf.json\' configuration file.", None))
+        self.cb_autoupdate.setText(QCoreApplication.translate("w_autoupdate", u"Check for dependency updates on startup.", None))
+        self.b_confirm.setText(QCoreApplication.translate("w_autoupdate", u"OK", None))
+    # retranslateUi
+

--- a/app/update_dialog.py
+++ b/app/update_dialog.py
@@ -1,0 +1,20 @@
+from PySide6.QtCore import QThread, Signal, QTimer
+from PySide6.QtWidgets import QWidget
+
+from ui.update_ui import Ui_w_autoupdate
+
+class UpdateUi(QWidget, Ui_w_autoupdate):
+    finished = Signal()
+    selected = Signal(bool)
+
+    def __init__(self):
+        super().__init__()
+        self.setupUi(self)
+        self.b_confirm.clicked.connect(self.on_b_confirm_clicked)
+
+    def on_b_confirm_clicked(self):
+        if self.cb_autoupdate.isChecked():
+            self.selected.emit(True)
+        else:
+            self.selected.emit(False)
+        self.finished.emit()

--- a/app/update_dialog.py
+++ b/app/update_dialog.py
@@ -13,8 +13,5 @@ class UpdateUi(QWidget, Ui_w_autoupdate):
         self.b_confirm.clicked.connect(self.on_b_confirm_clicked)
 
     def on_b_confirm_clicked(self):
-        if self.cb_autoupdate.isChecked():
-            self.selected.emit(True)
-        else:
-            self.selected.emit(False)
+        self.selected.emit(self.cb_autoupdate.isChecked())
         self.finished.emit()


### PR DESCRIPTION
# What does this PR do?
This:
- adds an auto-update and first-load option to `conf.json`
- adds a dialog box that, when the application is run for the first fime, asks the user if they want to automatically update yt-dlp on subsequent starts
- if yt-dlp is present in the `/bin` folder, compares the latest version hash with the hash of the executable, and triggers a download if the hashes do not match

# How to test it?
- Dialog should appear on startup if `conf.json` is missing or the `firstload` config option is true
- hashes should be compared if `autoupdate` is true
- hashes should not be compared and nothing should be downloaded if yt-dlp is on path but not present in /bin

This is my first pr for any project, so please be gentle. Feel free to shuffle things around a bit.

Closes #25 