### PR TITLE
[fix] Fix issue with --split-chapters option.

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -61,7 +61,7 @@ class Worker(qtc.QThread):
 
         args += self.args if isinstance(self.args, list) else shlex.split(self.args)
         args += self.global_args if isinstance(self.global_args, list) else shlex.split(self.global_args)
-        args += ["-o", f"{self.path}/%(title)s.%(ext)s", "--", self.link]
+        args += ["-P", f"{self.path}/", "--", self.link]
         return args
 
     def stop(self):


### PR DESCRIPTION
When using the _--split-chapters_ option of yt-dlp, the splited files are not saved in the specified location. To fix that, I suggest to use **-P** (path) instead of **-o** (output format) in the default args. This doesn't change the behaviour for single file, as yt-dlp apply something like _"%(title)s.%(ext)s_" by default for output file name. That way, the user can "override" (define) the **-o** option in his preset to have better control of the output file (or fileS if _--split-chapters_)