### PR TITLE
Automatically download pasted links when the download button is pressed

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -161,6 +161,11 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow):
         self.tw.clear()
 
     def button_download(self):
+        # If there are links in the text area, add them to the download list automatically using button_add
+        links = self.te_link.toPlainText().strip()
+        if links:
+            self.button_add()
+
         if not self.to_dl:
             return QtWidgets.QMessageBox.information(
                 self,


### PR DESCRIPTION
Issue being addressed: https://github.com/dsymbol/yt-dlp-gui/issues/63

Move links from text area to download list when user clicks download button if the list is empty.